### PR TITLE
Share ARIA live regions between multiple instances of A11ySpeak

### DIFF
--- a/a11y-speak.js
+++ b/a11y-speak.js
@@ -1,5 +1,4 @@
-var containerPolite = null;
-var containerAssertive = null;
+var containerPolite, containerAssertive;
 
 /**
  * Build the live regions markup.
@@ -43,11 +42,11 @@ var domReady = function( callback ) {
  * Create the live regions when the DOM is fully loaded.
  */
 domReady( function() {
-	if ( containerPolite === null ) {
+	if ( containerPolite = document.getElementById('a11y-speak-polite') === null ) {
 		containerPolite = addContainer( "polite" );
 	}
 
-	if ( containerAssertive === null ) {
+	if ( containerAssertive = document.getElementById('a11y-speak-assertive') === null ) {
 		containerAssertive = addContainer( "assertive" );
 	}
 });

--- a/a11y-speak.js
+++ b/a11y-speak.js
@@ -29,27 +29,31 @@ var addContainer = function( ariaLive ) {
  * Specify a function to execute when the DOM is fully loaded.
  *
  * @param {Function} callback A function to execute after the DOM is ready.
+ *
+ * @returns {void}
  */
 var domReady = function( callback ) {
-	if ( document.readyState === "complete" || ( document.readyState !== "loading" && ! document.documentElement.doScroll ) ) {
-		callback();
-	} else {
-		document.addEventListener( "DOMContentLoaded", callback );
+	if ( document.readyState === "complete" || ( document.readyState !== "loading" && !document.documentElement.doScroll ) ) {
+		return callback();
 	}
+
+	document.addEventListener( "DOMContentLoaded", callback );
 };
 
 /**
  * Create the live regions when the DOM is fully loaded.
  */
 domReady( function() {
-	if ( containerPolite = document.getElementById('a11y-speak-polite') === null ) {
+	containerPolite = document.getElementById( "a11y-speak-polite" );
+	containerAssertive = document.getElementById( "a11y-speak-assertive" );
+
+	if ( containerPolite === null ) {
 		containerPolite = addContainer( "polite" );
 	}
-
-	if ( containerAssertive = document.getElementById('a11y-speak-assertive') === null ) {
+	if ( containerAssertive === null ) {
 		containerAssertive = addContainer( "assertive" );
 	}
-});
+} );
 
 /**
  * Clear the live regions.


### PR DESCRIPTION
Whenever A11ySpeak is initialized, it checks if the ARIA live regions it needs are already present on the page before creating new ones.

Fixes #7 
